### PR TITLE
Implementation of the `Number` type

### DIFF
--- a/src/math/Cargo.toml
+++ b/src/math/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+fraction = "0.13.1"
 thiserror = "1"

--- a/src/math/Cargo.toml
+++ b/src/math/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 
 [dependencies]
 fraction = "0.13.1"
+rand = "0.8.5"
 thiserror = "1"

--- a/src/math/src/error.rs
+++ b/src/math/src/error.rs
@@ -25,4 +25,8 @@ pub enum Error {
     #[error("Negative root")]
     /// Negative root
     NegativeRoot,
+
+    #[error("Number is outside of range")]
+    /// Number is outside of range
+    OutOfRange,
 }

--- a/src/math/src/error.rs
+++ b/src/math/src/error.rs
@@ -3,7 +3,7 @@
 ///
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 /// Error type
 pub enum Error {
     #[error("Division zero")]
@@ -13,4 +13,8 @@ pub enum Error {
     #[error("Factorial of negative number")]
     /// Factorial of negative number
     FactorialNegative,
+
+    #[error("Log of a negative number")]
+    ///
+    LogNegativeBase,
 }

--- a/src/math/src/error.rs
+++ b/src/math/src/error.rs
@@ -14,7 +14,15 @@ pub enum Error {
     /// Factorial of negative number
     FactorialNegative,
 
-    #[error("Log of a negative number")]
-    ///
+    #[error("Logarithm to a negative base")]
+    /// Logarithm to a negative base
     LogNegativeBase,
+
+    #[error("Zero nth root")]
+    /// Zero nth root
+    ZeroNthRoot,
+
+    #[error("Negative root")]
+    /// Negative root
+    NegativeRoot,
 }

--- a/src/math/src/error.rs
+++ b/src/math/src/error.rs
@@ -8,5 +8,9 @@ use thiserror::Error;
 pub enum Error {
     #[error("Division zero")]
     /// Division zero
-    DivitionZero,
+    DivisionZero,
+
+    #[error("Factorial of negative number")]
+    /// Factorial of negative number
+    FactorialNegative,
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -72,7 +72,7 @@ impl Number {
     /// # use math::number::{Number, Radix};
     /// let pi = Numper::PI;
     /// let zero = Number::ZERO;
-    /// let neg = Number::from(-0.1);
+    /// let neg = Number::new(-1, 10);
     ///
     /// let precision = 6;
     ///
@@ -113,10 +113,10 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// let a = Number::from(0.1);
-    /// let b = Number::from(0.2);
+    /// let a = Number::new(1, 10);
+    /// let b = Number::new(2, 10);
     ///
-    /// assert_eq!(a.add(b), Ok(Number::from(0.3)));
+    /// assert_eq!(a.add(b), Ok(Number::new(3, 10)));
     /// assert_eq!(b.add(a), a.add(b));
     /// ```
     pub fn add(&self, other: impl Into<Self>) -> Result<Self> {
@@ -128,11 +128,11 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// let a = Number::from(0.1);
-    /// let b = Number::from(0.2);
+    /// let a = Number::new(1, 10);
+    /// let b = Number::new(2, 10);
     ///
-    /// assert_eq!(a.sub(b), Ok(Number::from(-0.1)));
-    /// assert_eq!(b.sub(a), Ok(Number::from(0.1)));
+    /// assert_eq!(a.sub(b), Ok(Number::from(-1, 10)));
+    /// assert_eq!(b.sub(a), Ok(Number::from(1, 10)));
     /// ```
     pub fn sub(&self, other: impl Into<Self>) -> Result<Self> {
         todo!()
@@ -143,11 +143,11 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// let a = Number::from(0.1);
-    /// let b = Number::from(0.2);
+    /// let a = Number::new(1, 10);
+    /// let b = Number::new(2, 10);
     ///
-    /// assert_eq!(a.mul(b), Ok(Number::from(-0.1)));
-    /// assert_ne!(b.mul(a), Ok(Number::from(0.1)));
+    /// assert_eq!(a.mul(b), Ok(Number::from(2, 100)));
+    /// assert_eq!(b.mul(a), a.mul(b));
     /// ```
     pub fn mul(&self, other: impl Into<Self>) -> Result<Self> {
         todo!()
@@ -168,8 +168,8 @@ impl Number {
     ///     assert_eq!(rand.div(rand)?, Number::ONE);
     ///
     ///     let a = Number::from(3);
-    ///     let b = Number::from(1.5);
-    ///     let neg_b = Number::from(-1.5);
+    ///     let b = Number::new(3, 2);
+    ///     let neg_b = Number::new(-3, 2);
     ///     assert_eq!(a.div(b)?, Number::from(2));
     ///     assert_eq!(a.div(neg_b)?, Number::from(-2));
     /// #   Ok(())
@@ -226,7 +226,7 @@ impl Number {
     /// # use math::Number;
     /// assert_eq!(Number::Zero.factorial(), Number::One);
     /// assert_eq!(Number::from(5).factorial(), Ok(Number::from(120)));
-    /// assert_eq!(Number::from(3.2).factorial().unwrap().to_string(6), "7.75669");
+    /// assert_eq!(Number::new(32, 10).factorial().unwrap().to_string(6), "7.75669");
     /// assert!(Number::from(-1).factorial().is_err());
     /// ```
     pub fn factorial(&self) -> Result<Self> {
@@ -246,7 +246,7 @@ impl Number {
     ///     assert!(Number::random().log(0).is_err());
     ///     assert!(Number::random().log(-1.2).is_err());
     ///     assert!(Number::ZERO.log(Number::random()).is_err());
-    ///     assert!(Number::from(-0.3).log(Number::random()).is_err());
+    ///     assert!(Number::new(-3, 10).log(Number::random()).is_err());
     ///
     ///     let a = Number::random();
     ///     let base = Number::random();

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -117,7 +117,7 @@ impl Number {
     /// let b = Number::from(0.2);
     ///
     /// assert_eq!(a.sub(b), Ok(Number::from(-0.1)));
-    /// assert_ne!(b.sub(a), Ok(Number::from(0.1)));
+    /// assert_eq!(b.sub(a), Ok(Number::from(0.1)));
     /// ```
     pub fn sub(&self, other: impl Into<Self>) -> Result<Self> {
         todo!()

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -169,6 +169,7 @@ impl Number {
     /// ```
     /// assert_eq!(Number::Zero.factorial(), Number::One);
     /// assert_eq!(Number::from(5).factorial(), Ok(Number::from(120)));
+    /// assert_eq!(Number::from(3.2).factorial().unwrap().to_string(6), "7.756689");
     /// assert!(Number::from(-1).factorial().is_err());
     /// ```
     pub fn factorial(&self) -> Result<Self> {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 /// Represent a number
 pub struct Number {
     inner: f64,
@@ -103,3 +105,25 @@ impl Number {
         todo!()
     }
 }
+
+impl Ord for Number {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner
+            .partial_cmp(&other.inner)
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for Number {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for Number {}

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -161,6 +161,16 @@ impl Number {
         todo!()
     }
 
+    /// Raises self to the power of `exp`, using exponentiation by squaring.
+    ///
+    /// ```
+    /// assert_eq!(Number::random().pow(Number::ZERO), Ok(Number::ONE));
+    /// assert_eq!(Number::from(5).pow(2), Ok(Number::from(25)));
+    /// ```
+    pub fn power(&self, exp: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
     /// Calculate factorial of a given number
     /// The number is not limited to integer, it can be a fraction
     ///

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -104,6 +104,8 @@ impl Number {
     /// Add two numbers together
     ///
     /// ```
+    /// # use math::Number;
+    ///
     /// let a = Number::from(0.1);
     /// let b = Number::from(0.2);
     ///
@@ -117,6 +119,8 @@ impl Number {
     /// Subtract two numbers
     ///
     /// ```
+    /// # use math::Number;
+    ///
     /// let a = Number::from(0.1);
     /// let b = Number::from(0.2);
     ///
@@ -130,6 +134,8 @@ impl Number {
     /// Multiply two numbers
     ///
     /// ```
+    /// # use math::Number;
+    ///
     /// let a = Number::from(0.1);
     /// let b = Number::from(0.2);
     ///
@@ -146,16 +152,21 @@ impl Number {
     /// Return Error::DivisionZero if `other` is 0
     ///
     /// ```
-    /// let random = Number::random();
-    /// assert!(random.div(Number::ZERO).is_err());
-    /// assert_eq!(Number::ZERO.div(random), Number::ZERO);
-    /// assert_eq!(rand.div(rand), Number::ONE);
+    /// # use math::Number;
     ///
-    /// let a = Number::from(3);
-    /// let b = Number::from(1.5);
-    /// let neg_b = Number::from(-1.5);
-    /// assert_eq!(a.div(b), Ok(Number::from(2)));
-    /// assert_eq!(a.div(neg_b), Ok(Number::from(-2)))
+    /// # fn main() -> math::Result<()> {
+    ///     let random = Number::random();
+    ///     assert!(random.div(Number::ZERO).is_err());
+    ///     assert_eq!(Number::ZERO.div(random)?, Number::ZERO);
+    ///     assert_eq!(rand.div(rand)?, Number::ONE);
+    ///
+    ///     let a = Number::from(3);
+    ///     let b = Number::from(1.5);
+    ///     let neg_b = Number::from(-1.5);
+    ///     assert_eq!(a.div(b)?, Number::from(2));
+    ///     assert_eq!(a.div(neg_b)?, Number::from(-2));
+    /// #   Ok(())
+    /// # }
     /// ```
     pub fn div(&self, other: impl Into<Self>) -> Result<Self> {
         todo!()
@@ -164,6 +175,7 @@ impl Number {
     /// Raises self to the power of `exp`, using exponentiation by squaring.
     ///
     /// ```
+    /// # use math::Number;
     /// assert_eq!(Number::random().pow(Number::ZERO), Ok(Number::ONE));
     /// assert_eq!(Number::from(5).pow(2), Ok(Number::from(25)));
     /// ```
@@ -174,6 +186,7 @@ impl Number {
     /// Get the remainder of `self / other`
     ///
     /// ```
+    /// # use math::Number;
     /// assert_eq!(Number::from(5).modulo(2), Ok(Number::ONE));
     /// ```
     pub fn modulo(&self, other: impl Into<Self>) -> Result<Self> {
@@ -185,7 +198,9 @@ impl Number {
     ///
     /// # Error
     /// return Error::FactorialNegative if the number is less than 0
+    ///
     /// ```
+    /// # use math::Number;
     /// assert_eq!(Number::Zero.factorial(), Number::One);
     /// assert_eq!(Number::from(5).factorial(), Ok(Number::from(120)));
     /// assert_eq!(Number::from(3.2).factorial().unwrap().to_string(6), "7.756689");
@@ -202,27 +217,32 @@ impl Number {
     /// Error::LogUndefinedNumber if the number is less or equal than 0
     ///
     /// ```
-    /// assert!(Number::random().log(0).is_err());
-    /// assert!(Number::random().log(-1.2).is_err());
-    /// assert!(Number::ZERO.log(Number::random()).is_err());
-    /// assert!(Number::from(-0.3).log(Number::random()).is_err());
+    /// # use math::Number;
     ///
-    /// let a = Number::random();
-    /// let base = Number::random();
-    /// let b = Number::from(2);
+    /// # fn main() -> math::Result<()> {
+    ///     assert!(Number::random().log(0).is_err());
+    ///     assert!(Number::random().log(-1.2).is_err());
+    ///     assert!(Number::ZERO.log(Number::random()).is_err());
+    ///     assert!(Number::from(-0.3).log(Number::random()).is_err());
     ///
-    /// // Number same as base
-    /// assert_eq!(a.log(a), Ok(Number::ONE));
-    /// // Product rule log(xy) == log(x) + log(y)
-    /// assert_eq!(a.mul(b).unwrap().log(base), a.log(base).add(b.log(base).unwrap()));
-    /// // Quotient rule log(x/y) == log(x) - log(y)
-    /// assert_eq!(a.div(b).unwrap().log(base), a.log(base).sub(b.log(base).unwrap()));
-    /// // Log of power log(x^y) == y * log(x)
-    /// assert_eq!(a.pow(b).unwrap().log(base), b.mul(a.log(base).unwrap()));
-    /// // Log of one
-    /// assert_eq!(Number::ONE.log(base), Ok(Number::ZERO));
-    /// // Log reciprocal log(1/x) = -ln(x);
-    /// assert_eq!(Number::ONE.div(a).unwrap().log(base), a.log(base).and_then(|v| v.mul(-1)));
+    ///     let a = Number::random();
+    ///     let base = Number::random();
+    ///     let b = Number::from(2);
+    ///
+    ///     // Number same as base
+    ///     assert_eq!(a.log(a)?, Number::ONE);
+    ///     // Product rule log(xy) == log(x) + log(y)
+    ///     assert_eq!(a.mul(b)?.log(base), a.log(base).add(b.log(base)?));
+    ///     // Quotient rule log(x/y) == log(x) - log(y)
+    ///     assert_eq!(a.div(b)?.log(base), a.log(base).sub(b.log(base)?));
+    ///     // Log of power log(x^y) == y * log(x)
+    ///     assert_eq!(a.pow(b)?.log(base), b.mul(a.log(base)?));
+    ///     // Log of one
+    ///     assert_eq!(Number::ONE.log(base)?, Number::ZERO);
+    ///     // Log reciprocal log(1/x) = -ln(x);
+    ///     assert_eq!(Number::ONE.div(a)?.log(base), a.log(base)?.mul(-1));
+    ///     # Ok(())
+    /// # }
     /// ```
     pub fn log(&self, base: impl Into<Self>) -> Result<Self> {
         todo!()

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -17,6 +17,18 @@ impl Number {
         precision: 6,
     };
 
+    /// 3.14159...
+    pub const PI: Self = Self {
+        inner: std::f64::consts::PI,
+        precision: 6,
+    };
+
+    /// 2.71828...
+    pub const E: Self = Self {
+        inner: std::f64::consts::E,
+        precision: 6,
+    };
+
     ///
     pub fn to_string_radix(&self, _radix: u8) -> String {
         todo!()

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -465,6 +465,39 @@ impl Number {
     pub fn arccotg(&self) -> Result<Self> {
         todo!()
     }
+
+    /// Calculate combination number of the given `n` and `k`
+    ///
+    /// Since combination number is defined as `C(n, k)` mathematically
+    /// Neither `n` nor `k` is considered the center of the function
+    /// that's why this function does not taking `self` as parameter like other functions
+    ///
+    /// # Error
+    /// Error::FactorialNegative if either `n` or `k` is negative, because they will need to be factorialized
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<Self> {
+    ///     assert!(Number::combination(-1, Number::random()).is_err());
+    ///     assert!(Number::combination(Number::random(), -1).is_err());
+    ///
+    ///     let n = Number::random();
+    ///
+    ///     // if k > n => C(n, k) == 0
+    ///     assert_eq!(Number::combination(4, 3)?, Number::ZERO);
+    ///     // C(n, 0) == 1
+    ///     assert_eq!(Number::combination(n, 0)?, Number::ONE);
+    ///     // C(n, 1) == n
+    ///     assert_eq!(Number::combination(n, 1)?, n);
+    ///     // C(n, n) == 1
+    ///     assert_eq!(Number::combination(n, n)?, Number::ONE);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn combination(n: impl Into<Self>, k: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
 }
 
 impl Ord for Number {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use std::cmp::Ordering;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 /// Represent a number
 pub struct Number {
     inner: f64,

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -1,15 +1,21 @@
 /// Represent a number
-pub struct Number(f64);
+pub struct Number {
+    inner: f64,
+    precision: u8,
+}
 
 impl AsRef<f64> for Number {
     fn as_ref(&self) -> &f64 {
-        &self.0
+        &self.inner
     }
 }
 
 impl Number {
     /// 0.0
-    pub const ZERO: Number = Self(0.0);
+    pub const ZERO: Self = Self {
+        inner: 0.0,
+        precision: 6,
+    };
 
     ///
     pub fn to_string_radix(&self, _radix: u8) -> String {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -269,6 +269,43 @@ impl Number {
     pub fn log10(&self) -> Result<Self> {
         todo!()
     }
+
+    /// Returns the nth root of a number
+    ///
+    /// # Error
+    /// Error::ZeroNthRoot if the `nth` is 0
+    /// Error::NegativeRoot if the number is negative
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     assert!(Number::random().root(0).is_err());
+    ///     assert!(Number::from(-1).root(Number::random()).is_err());
+    ///
+    ///     let a = Number::random();
+    ///     let b = Number::random();
+    ///     let nth = Number::random();
+    ///
+    ///     // root(a^nth) == a
+    ///     assert_er!(a.pow(nth)?.root(nth), a);
+    ///     // root(ab) == root(a) * root(b)
+    ///     assert_eq!(a.mul(b)?.root(nth), a.root(nth)?.mul(b.root(nth)?));
+    ///     // root(a/b) == root(a) / root(b)
+    ///     assert_eq!(a.div(b)?.root(nth), a.root(nth)?.div(b.root(nth)?));
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn root(&self, nth: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
+    /// Returns the square root of a number.
+    /// This function is the same as `root` with the `nth` of 2
+    pub fn sqrt(&self) -> Result<Self> {
+        todo!()
+    }
 }
 
 impl Ord for Number {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -60,6 +60,8 @@ impl Number {
     /// ```
     /// # use math::Number;
     /// assert!(Number::new(43, 0).is_err());
+    /// assert!(Number::new(30, 10), Number::new(3, 10));
+    /// assert!(Number::new(2, 10), Number::new(1, 5));
     /// assert_eq!(Number::new(1, 10).unwrap().to_string(Radix::Dec, 5), "0.1");
     /// ```
     pub fn new(num: i64, denom: i64) -> Result<Self> {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -51,6 +51,21 @@ impl Number {
         inner: std::f64::consts::E,
     };
 
+    /// Create a new number in the form `num / denom`
+    /// This way we can safely create number can cannot be expressed in binary form like 0.1
+    ///
+    /// # Error
+    /// Error::DivisionZero if `denom` is 0
+    ///
+    /// ```
+    /// # use math::Number;
+    /// assert!(Number::new(43, 0).is_err());
+    /// assert_eq!(Number::new(1, 10).unwrap().to_string(Radix::Dec, 5), "0.1");
+    /// ```
+    pub fn new(num: i64, denom: i64) -> Result<Self> {
+        todo!()
+    }
+
     /// Get the formatted string of a number
     ///
     /// ```

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -202,11 +202,11 @@ impl Number {
     ///     let random = Number::random();
     ///     assert!(random.div(Number::ZERO).is_err());
     ///     assert_eq!(Number::ZERO.div(random)?, Number::ZERO);
-    ///     assert_eq!(rand.div(rand)?, Number::ONE);
+    ///     assert_eq!(random.div(random)?, Number::ONE);
     ///
     ///     let a = Number::from(3);
-    ///     let b = Number::new(3, 2);
-    ///     let neg_b = Number::new(-3, 2);
+    ///     let b = Number::new(3, 2)?;
+    ///     let neg_b = Number::new(-3, 2)?;
     ///     assert_eq!(a.div(b)?, Number::from(2));
     ///     assert_eq!(a.div(neg_b)?, Number::from(-2));
     /// #   Ok(())

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -165,7 +165,7 @@ impl Number {
     /// The number is not limited to integer, it can be a fraction
     ///
     /// # Error
-    /// return
+    /// return Error::FactorialNegative if the number is less than 0
     /// ```
     /// assert_eq!(Number::Zero.factorial(), Number::One);
     /// assert_eq!(Number::from(5).factorial(), Ok(Number::from(120)));

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -1,10 +1,25 @@
 use crate::Result;
 use std::cmp::Ordering;
 
-/// Represent a number
 #[derive(Debug, Clone, Copy)]
+/// Represent a number
 pub struct Number {
     inner: f64,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+#[non_exhaustive]
+/// Radix to use to represent a Number
+pub enum Radix {
+    /// Binary
+    Bin,
+    /// Octal
+    Oct,
+    #[default]
+    /// Decimal - default
+    Dec,
+    /// Hexadecimal
+    Hex,
 }
 
 impl<T: Into<f64>> From<T> for Number {
@@ -18,6 +33,7 @@ impl AsRef<f64> for Number {
         &self.inner
     }
 }
+
 impl Number {
     /// 0.0
     pub const ZERO: Self = Self { inner: 0.0 };
@@ -35,63 +51,32 @@ impl Number {
         inner: std::f64::consts::E,
     };
 
-    /// Get the decimal string
+    /// Get the formatted string of a number
     ///
     /// ```
-    /// let pi = Number::PI.to_string(6);
-    /// let zero = Number::ZERO.to_string(6);
-    /// let neg = Number::from(-0.1).to_string(6);
+    /// # use math::number::{Number, Radix};
+    /// let pi = Numper::PI;
+    /// let zero = Number::ZERO;
+    /// let neg = Number::from(-0.1);
     ///
-    /// assert_eq!(zero, "0");
-    /// assert_eq!(neg, "-0.1");
-    /// assert!(pi, "3.141592"); // default precision is 6 decimal points
-    /// ```
-    pub fn to_string(&self, precision: u8) -> String {
-        todo!()
-    }
-
-    /// Get the binary string
+    /// let precision = 6;
     ///
-    /// ```
-    /// let pi = Number::PI.to_string_binary(6);
-    /// let zero = Number::ZERO.to_string_binary(6);
-    /// let neg = Number::from(-0.1).to_string_binary(6);
+    /// assert_eq!(zero.to_string(Radix::Bin, precision), "0");
+    /// assert_eq!(zero.to_string(Radix::Oct, precision), "0");
+    /// assert_eq!(zero.to_string(Radix::Dec, precision), "0");
+    /// assert_eq!(zero.to_string(Radix::Hex, precision), "0");
     ///
-    /// assert_eq!(zero, "0");
-    /// assert_eq!(neg, "-0.1");
-    /// assert!(pi.starts_with("3.14159"));
-    /// ```
-    pub fn to_string_binary(&self, precision: u8) -> String {
-        todo!()
-    }
-
-    /// Get the octal string
+    /// assert_eq!(pi.to_string(Default::default(), precision), "3.141592");
+    /// assert_eq!(pi.to_string(Radix::Bin, precision), "11.001001");
+    /// assert_eq!(pi.to_string(Radix::Oct, precision), "3.110375");
+    /// assert_eq!(pi.to_string(Radix::Hex, precision), "3.243F6A");
     ///
+    /// assert_eq!(neg.to_string(Default::default(), precision), "-0.1");
+    /// assert_eq!(neg.to_string(Radix::Bin, precision), "-0.00011");
+    /// assert_eq!(neg.to_string(Radix::Oct, precision), "-0.063146");
+    /// assert_eq!(neg.to_string(Radix::Hex, precision), "-0.199999");
     /// ```
-    /// let pi = Number::PI.to_string_octal(6);
-    /// let zero = Number::ZERO.to_string_octal(6);
-    /// let neg = Number::from(-0.1).to_string_octal(6);
-    ///
-    /// assert_eq!(zero, "0");
-    /// assert_eq!(neg, "-0.063146");
-    /// assert!(pi, "3.11037");
-    /// ```
-    pub fn to_string_octal(&self, precision: u8) -> String {
-        todo!()
-    }
-
-    /// Get the hexadecimal string
-    ///
-    /// ```
-    /// let pi = Number::PI.to_string_hex(6);
-    /// let zero = Number::ZERO.to_string_hex(6);
-    /// let neg = Number::from(-0.1).to_string_hex(6);
-    ///
-    /// assert_eq!(zero, "0");
-    /// assert_eq!(neg, "-0.199999");
-    /// assert!(pi.starts_with("3.243F6A"));
-    /// ```
-    pub fn to_string_hex(&self, precision: u8) -> String {
+    pub fn to_string(&self, radix: Radix, precision: u8) -> String {
         todo!()
     }
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -87,6 +87,17 @@ impl Number {
 }
 
 impl Number {
+    /// Generate a random number in range of <0, 1>
+    ///
+    /// ```
+    /// assert_ne!(Number::random(), Number::random());
+    /// assert_ge!(Number::random(), Number::Zero);
+    /// assert_le!(Number::random(), Number::One);
+    /// ```
+    pub fn random() -> Self {
+        todo!()
+    }
+
     /// Add two numbers together
     ///
     /// ```

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -169,11 +169,14 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// let a = Number::new(1, 10);
-    /// let b = Number::new(2, 10);
+    /// # fn main() -> math::Result<()> {
+    ///     let a = Number::new(1, 10)?;
+    ///     let b = Number::new(2, 10)?;
     ///
-    /// assert_eq!(a.mul(b), Ok(Number::from(2, 100)));
-    /// assert_eq!(b.mul(a), a.mul(b));
+    ///     assert_eq!(a.mul(b)?, Number::new(2, 100)?);
+    ///     assert_eq!(b.mul(a), a.mul(b));
+    /// #     Ok(())
+    /// # }
     /// ```
     pub fn mul(&self, other: impl Into<Self>) -> Result<Self> {
         Ok(Self {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -282,7 +282,10 @@ impl Number {
     ///
     /// # fn main() -> math::Result<()> {
     ///     assert!(Number::random().root(0).is_err());
-    ///     assert!(Number::from(-1).root(Number::random()).is_err());
+    ///     assert!(Number::from(-1).root(2).is_err());
+    ///     assert!(Number::from(-1).root(88).is_err());
+    ///     assert!(Number::from(-1).root(3).is_ok());
+    ///     assert!(Number::from(-1).root(87).is_ok());
     ///
     ///     let a = Number::random();
     ///     let b = Number::random();

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -2,7 +2,7 @@ use crate::Result;
 use std::cmp::Ordering;
 
 /// Represent a number
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Number {
     inner: f64,
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -116,12 +116,18 @@ impl Number {
     ///
     /// ```
     /// # use math::Number;
-    /// assert_ne!(Number::random(), Number::random());
-    /// assert_ge!(Number::random(), Number::Zero);
-    /// assert_le!(Number::random(), Number::One);
+    /// assert!(Number::random() != Number::random());
+    /// assert!(Number::random() >= Number::ZERO);
+    /// assert!(Number::random() <= Number::ONE);
     /// ```
     pub fn random() -> Self {
-        todo!()
+        use rand::prelude::*;
+
+        let mut rng = rand::thread_rng();
+        let denom: u64 = rng.gen_range(1..(u64::MAX / 2));
+        let num: u64 = rng.gen_range(0..=denom);
+
+        Self::new_unchecked(num as _, denom as _)
     }
 
     /// Add two numbers together

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -83,9 +83,9 @@ impl Number {
     /// Get the hexadecimal string
     ///
     /// ```
-    /// let pi = Number::PI.to_string_hex();
-    /// let zero = Number::ZERO.to_string_hex();
-    /// let neg = Number::from(-0.1).to_string_hex();
+    /// let pi = Number::PI.to_string_hex(6);
+    /// let zero = Number::ZERO.to_string_hex(6);
+    /// let neg = Number::from(-0.1).to_string_hex(6);
     ///
     /// assert_eq!(zero, "0");
     /// assert_eq!(neg, "-0.199999");
@@ -398,6 +398,86 @@ impl Number {
     /// # }
     /// ```
     pub fn cotg(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the arcsine of a number. Return value is in radians in the range <-pi/2, pi/2>
+    ///
+    /// # Error
+    /// Error::OutOfRange if the number is not in the range <-1, 1>
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     assert!(Number::from(-2).arcsin().is_err());
+    ///     assert!(Number::from(2).arcsin().is_err());
+    ///     let x = Number::random();
+    ///     let sin_x = x.sin()?;
+    ///
+    ///     assert_eq!(x, sin_x.arcsin()?);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn arcsin(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the arccosine of a number. Return value is in radians in the range <0, pi>
+    ///
+    /// # Error
+    /// Error::OutOfRange if the number is not in the range <-1, 1>
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     assert!(Number::from(-2).arccos().is_err());
+    ///     assert!(Number::from(2).arccos().is_err());
+    ///     let x = Number::random();
+    ///     let cos_x = x.cos()?;
+    ///
+    ///     assert_eq!(x, cos_x.arccos()?);
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn arccos(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the arctangent of a number. Return value is in radians in the range <-pi/2, pi/2>
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     let x = Number::random();
+    ///     let tan_x = x.tg()?;
+    ///
+    ///     assert_eq!(x, tan_x.arctg()?);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn arctg(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the arccotangent of a number. Return value is in radians in the range <0, pi>
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     let x = Number::random();
+    ///     let cot_x = x.cotg()?;
+    ///
+    ///     assert_eq!(x, cot_x.arccotg()?);
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn arccotg(&self) -> Result<Self> {
         todo!()
     }
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -115,6 +115,7 @@ impl Number {
     /// Generate a random number in range of <0, 1>
     ///
     /// ```
+    /// # use math::Number;
     /// assert_ne!(Number::random(), Number::random());
     /// assert_ge!(Number::random(), Number::Zero);
     /// assert_le!(Number::random(), Number::One);
@@ -128,11 +129,14 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// let a = Number::new(1, 10);
-    /// let b = Number::new(2, 10);
+    /// # fn main() -> math::Result<()> {
+    /// let a = Number::new(1, 10)?;
+    /// let b = Number::new(2, 10)?;
     ///
-    /// assert_eq!(a.add(b), Ok(Number::new(3, 10)));
+    /// assert_eq!(a.add(b)?, Number::new(3, 10)?);
     /// assert_eq!(b.add(a), a.add(b));
+    /// #     Ok(())
+    /// # }
     /// ```
     pub fn add(&self, other: impl Into<Self>) -> Result<Self> {
         Ok(Self {
@@ -527,7 +531,7 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// # fn main() -> math::Result<Self> {
+    /// # fn main() -> math::Result<()> {
     ///     assert!(Number::combination(-1, Number::random()).is_err());
     ///     assert!(Number::combination(Number::random(), -1).is_err());
     ///

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -550,7 +550,7 @@ impl Number {
     ///     let n = Number::random();
     ///
     ///     // if k > n => C(n, k) == 0
-    ///     assert_eq!(Number::combination(4, 3)?, Number::ZERO);
+    ///     assert_eq!(Number::combination(3, 4)?, Number::ZERO);
     ///     // C(n, 0) == 1
     ///     assert_eq!(Number::combination(n, 0)?, Number::ONE);
     ///     // C(n, 1) == n

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -29,8 +29,77 @@ impl Number {
         precision: 6,
     };
 
+    /// Set the maximum precision of the Number
+    /// This only affect the `to_string` (and its related) function
+    /// The calculation is unaffected
     ///
-    pub fn to_string_radix(&self, _radix: u8) -> String {
+    /// ```
+    /// let mut e = Number::E;
+    /// assert_eq!(e.to_string(), "2.718281");
+    /// e.set_precision(2);
+    /// assert_eq!(e.to_string(), "2.71");
+    /// ```
+    pub fn set_precision(&mut self, precision: u8) {
+        self.precision = precision;
+    }
+
+    /// Get the decimal string
+    ///
+    /// ```
+    /// let pi = Number::PI.to_string();
+    /// let zero = Number::ZERO.to_string();
+    /// let neg = Number::from(-0.1).to_string();
+    ///
+    /// assert_eq!(zero, "0");
+    /// assert_eq!(neg, "-0.1");
+    /// assert!(pi, "3.141592"); // default precision is 6 decimal points
+    /// ```
+    pub fn to_string(&self) -> String {
+        todo!()
+    }
+
+    /// Get the binary string
+    ///
+    /// ```
+    /// let pi = Number::PI.to_string_binary();
+    /// let zero = Number::ZERO.to_string_binary();
+    /// let neg = Number::from(-0.1).to_string_binary();
+    ///
+    /// assert_eq!(zero, "0");
+    /// assert_eq!(neg, "-0.1");
+    /// assert!(pi.starts_with("3.14159"));
+    /// ```
+    pub fn to_string_binary(&self) -> String {
+        todo!()
+    }
+
+    /// Get the octal string
+    ///
+    /// ```
+    /// let pi = Number::PI.to_string_octal();
+    /// let zero = Number::ZERO.to_string_octal();
+    /// let neg = Number::from(-0.1).to_string_octal();
+    ///
+    /// assert_eq!(zero, "0");
+    /// assert_eq!(neg, "-0.00011");
+    /// assert!(pi, "11.001001");
+    /// ```
+    pub fn to_string_octal(&self) -> String {
+        todo!()
+    }
+
+    /// Get the hexadecimal string
+    ///
+    /// ```
+    /// let pi = Number::PI.to_string_hex();
+    /// let zero = Number::ZERO.to_string_hex();
+    /// let neg = Number::from(-0.1).to_string_hex();
+    ///
+    /// assert_eq!(zero, "0");
+    /// assert_eq!(neg, "-0.199999");
+    /// assert!(pi.starts_with("3.243F6A"));
+    /// ```
+    pub fn to_string_hex(&self) -> String {
         todo!()
     }
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -70,7 +70,7 @@ impl Number {
         let n = num.abs() as u64;
         let d = denom.abs() as u64;
 
-        let sign = if (num * denom).is_positive() {
+        let sign = if num.is_positive() == denom.is_positive() {
             fraction::Sign::Plus
         } else {
             fraction::Sign::Minus

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -320,6 +320,86 @@ impl Number {
     pub fn sqrt(&self) -> Result<Self> {
         todo!()
     }
+
+    /// Computes the sine of a number (in radians).
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     let x = Number::random();
+    ///     let half_pi = Number::PI.div(2)?;
+    ///     let sin_x = x.sin();
+    ///
+    ///     // sin(x) == cos(PI/2 - x)
+    ///     assert_eq!(sin_x, half_pi.sub(x)?.cos());
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn sin(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the cosine of a number (in radians).
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     let x = Number::random();
+    ///     let half_pi = Number::PI.div(2)?;
+    ///     let cos_x = x.cos();
+    ///
+    ///     // cos(x) == sin(PI/2 - x)
+    ///     assert_eq!(cos_x, half_pi.sub(x)?.sin());
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn cos(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the tangent of a number (in radians).
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     let x = Number::random();
+    ///     let tan_x = x.tg();
+    ///
+    ///     // tg(x) == sin(x) / cos(x)
+    ///     assert_eq!(tan_x, x.sin()?.div(x.cos()?));
+    ///     // tg(x) == 1 / cotg(x)
+    ///     assert_eq!(tan_x, Number::ONE.div(x.cotg()?));
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn tg(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Computes the cotangent of a number (in radians).
+    ///
+    /// ```
+    /// # use math::Number;
+    ///
+    /// # fn main() -> math::Result<()> {
+    ///     let x = Number::random();
+    ///     let cot_x = x.cotg();
+    ///
+    ///     // cotg(x) == cos(x) / sin(x)
+    ///     assert_eq!(cot_x, x.cos()?.div(x.sin()?));
+    ///     // cotg(x) == 1 / tg(x)
+    ///     assert_eq!(cot_x, Number::ONE.div(x.tg()?));
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn cotg(&self) -> Result<Self> {
+        todo!()
+    }
 }
 
 impl Ord for Number {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -194,6 +194,54 @@ impl Number {
     pub fn factorial(&self) -> Result<Self> {
         todo!()
     }
+
+    /// Returns the logarithm of the number with respect to an arbitrary `base`.
+    ///
+    /// # Error
+    /// Error::LogUndefinedBase if the `base` is less or equal than 0
+    /// Error::LogUndefinedNumber if the number is less or equal than 0
+    ///
+    /// ```
+    /// assert!(Number::random().log(0).is_err());
+    /// assert!(Number::random().log(-1.2).is_err());
+    /// assert!(Number::ZERO.log(Number::random()).is_err());
+    /// assert!(Number::from(-0.3).log(Number::random()).is_err());
+    ///
+    /// let a = Number::random();
+    /// let base = Number::random();
+    /// let b = Number::from(2);
+    ///
+    /// // Number same as base
+    /// assert_eq!(a.log(a), Ok(Number::ONE));
+    /// // Product rule log(xy) == log(x) + log(y)
+    /// assert_eq!(a.mul(b).unwrap().log(base), a.log(base).add(b.log(base).unwrap()));
+    /// // Quotient rule log(x/y) == log(x) - log(y)
+    /// assert_eq!(a.div(b).unwrap().log(base), a.log(base).sub(b.log(base).unwrap()));
+    /// // Log of power log(x^y) == y * log(x)
+    /// assert_eq!(a.pow(b).unwrap().log(base), b.mul(a.log(base).unwrap()));
+    /// // Log of one
+    /// assert_eq!(Number::ONE.log(base), Ok(Number::ZERO));
+    /// // Log reciprocal log(1/x) = -ln(x);
+    /// assert_eq!(Number::ONE.div(a).unwrap().log(base), a.log(base).and_then(|v| v.mul(-1)));
+    /// ```
+    pub fn log(&self, base: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
+    /// Same as `Number::log` with `base` of 2
+    pub fn log2(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Same as `Number::log` with `base` of `Number::E`
+    pub fn ln(&self) -> Result<Self> {
+        todo!()
+    }
+
+    /// Same as `Number::log` with `base` of 10
+    pub fn log10(&self) -> Result<Self> {
+        todo!()
+    }
 }
 
 impl Ord for Number {

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -171,6 +171,15 @@ impl Number {
         todo!()
     }
 
+    /// Get the remainder of `self / other`
+    ///
+    /// ```
+    /// assert_eq!(Number::from(5).modulo(2), Ok(Number::ONE));
+    /// ```
+    pub fn modulo(&self, other: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
     /// Calculate factorial of a given number
     /// The number is not limited to integer, it can be a fraction
     ///

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -1,9 +1,9 @@
+use crate::Result;
 use std::cmp::Ordering;
 
 /// Represent a number
 pub struct Number {
     inner: f64,
-    precision: u8,
 }
 
 impl AsRef<f64> for Number {
@@ -11,82 +11,62 @@ impl AsRef<f64> for Number {
         &self.inner
     }
 }
-
 impl Number {
     /// 0.0
-    pub const ZERO: Self = Self {
-        inner: 0.0,
-        precision: 6,
-    };
+    pub const ZERO: Self = Self { inner: 0.0 };
 
     /// 3.14159...
     pub const PI: Self = Self {
         inner: std::f64::consts::PI,
-        precision: 6,
     };
 
     /// 2.71828...
     pub const E: Self = Self {
         inner: std::f64::consts::E,
-        precision: 6,
     };
-
-    /// Set the maximum precision of the Number
-    /// This only affect the `to_string` (and its related) function
-    /// The calculation is unaffected
-    ///
-    /// ```
-    /// let mut e = Number::E;
-    /// assert_eq!(e.to_string(), "2.718281");
-    /// e.set_precision(2);
-    /// assert_eq!(e.to_string(), "2.71");
-    /// ```
-    pub fn set_precision(&mut self, precision: u8) {
-        self.precision = precision;
-    }
 
     /// Get the decimal string
     ///
     /// ```
-    /// let pi = Number::PI.to_string();
-    /// let zero = Number::ZERO.to_string();
-    /// let neg = Number::from(-0.1).to_string();
+    /// let pi = Number::PI.to_string(6);
+    /// let zero = Number::ZERO.to_string(6);
+    /// let neg = Number::from(-0.1).to_string(6);
     ///
     /// assert_eq!(zero, "0");
     /// assert_eq!(neg, "-0.1");
     /// assert!(pi, "3.141592"); // default precision is 6 decimal points
     /// ```
-    pub fn to_string(&self) -> String {
+    pub fn to_string(&self, precision: u8) -> String {
         todo!()
     }
 
     /// Get the binary string
     ///
     /// ```
-    /// let pi = Number::PI.to_string_binary();
-    /// let zero = Number::ZERO.to_string_binary();
-    /// let neg = Number::from(-0.1).to_string_binary();
+    /// let pi = Number::PI.to_string_binary(6);
+    /// let zero = Number::ZERO.to_string_binary(6);
+    /// let neg = Number::from(-0.1).to_string_binary(6);
     ///
     /// assert_eq!(zero, "0");
     /// assert_eq!(neg, "-0.1");
     /// assert!(pi.starts_with("3.14159"));
     /// ```
-    pub fn to_string_binary(&self) -> String {
+    pub fn to_string_binary(&self, precision: u8) -> String {
         todo!()
     }
 
     /// Get the octal string
     ///
     /// ```
-    /// let pi = Number::PI.to_string_octal();
-    /// let zero = Number::ZERO.to_string_octal();
-    /// let neg = Number::from(-0.1).to_string_octal();
+    /// let pi = Number::PI.to_string_octal(6);
+    /// let zero = Number::ZERO.to_string_octal(6);
+    /// let neg = Number::from(-0.1).to_string_octal(6);
     ///
     /// assert_eq!(zero, "0");
-    /// assert_eq!(neg, "-0.00011");
-    /// assert!(pi, "11.001001");
+    /// assert_eq!(neg, "-0.063146");
+    /// assert!(pi, "3.11037");
     /// ```
-    pub fn to_string_octal(&self) -> String {
+    pub fn to_string_octal(&self, precision: u8) -> String {
         todo!()
     }
 
@@ -101,7 +81,68 @@ impl Number {
     /// assert_eq!(neg, "-0.199999");
     /// assert!(pi.starts_with("3.243F6A"));
     /// ```
-    pub fn to_string_hex(&self) -> String {
+    pub fn to_string_hex(&self, precision: u8) -> String {
+        todo!()
+    }
+}
+
+impl Number {
+    /// Add two numbers together
+    ///
+    /// ```
+    /// let a = Number::from(0.1);
+    /// let b = Number::from(0.2);
+    ///
+    /// assert_eq!(a.add(b), Ok(Number::from(0.3)));
+    /// assert_eq!(b.add(a), a.add(b));
+    /// ```
+    pub fn add(&self, other: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
+    /// Subtract two numbers
+    ///
+    /// ```
+    /// let a = Number::from(0.1);
+    /// let b = Number::from(0.2);
+    ///
+    /// assert_eq!(a.sub(b), Ok(Number::from(-0.1)));
+    /// assert_ne!(b.sub(a), Ok(Number::from(0.1)));
+    /// ```
+    pub fn sub(&self, other: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
+    /// Multiply two numbers
+    ///
+    /// ```
+    /// let a = Number::from(0.1);
+    /// let b = Number::from(0.2);
+    ///
+    /// assert_eq!(a.mul(b), Ok(Number::from(-0.1)));
+    /// assert_ne!(b.mul(a), Ok(Number::from(0.1)));
+    /// ```
+    pub fn mul(&self, other: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
+    /// Divide two numbers
+    ///
+    /// # Error
+    /// Return Error::DivisionZero if `other` is 0
+    ///
+    /// ```
+    /// let random = Number::random();
+    /// assert!(random.div(Number::ZERO).is_err());
+    /// assert_eq!(Number::ZERO.div(random), Number::ZERO);
+    /// assert_eq!(rand.div(rand), Number::ONE);
+    /// let a = Number::from(3);
+    /// let b = Number::from(1.5);
+    /// let neg_b = Number::from(-1.5);
+    /// assert_eq!(a.div(b), Ok(Number::from(2)));
+    /// assert_eq!(a.div(neg_b), Ok(Number::from(-2)))
+    /// ```
+    pub fn div(&self, other: impl Into<Self>) -> Result<Self> {
         todo!()
     }
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -149,15 +149,18 @@ impl Number {
     /// ```
     /// # use math::Number;
     ///
-    /// let a = Number::new(1, 10);
-    /// let b = Number::new(2, 10);
+    /// # fn main() -> math::Result<()> {
+    ///     let a = Number::new(1, 10)?;
+    ///     let b = Number::new(2, 10)?;
     ///
-    /// assert_eq!(a.sub(b), Ok(Number::from(-1, 10)));
-    /// assert_eq!(b.sub(a), Ok(Number::from(1, 10)));
+    ///     assert_eq!(a.sub(b)?, Number::new(-1, 10)?);
+    ///     assert_eq!(b.sub(a)?, Number::new(1, 10)?);
+    /// #     Ok(())
+    /// # }
     /// ```
     pub fn sub(&self, other: impl Into<Self>) -> Result<Self> {
         Ok(Self {
-            inner: self.inner + other.into().inner,
+            inner: self.inner - other.into().inner,
         })
     }
 

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -180,6 +180,8 @@ impl Number {
     /// ```
     /// # use math::Number;
     /// assert_eq!(Number::from(5).modulo(2), Ok(Number::ONE));
+    /// assert_eq!(Number::from(-5).modulo(2), Ok(Number::ONE));
+    /// assert_eq!(Number::from(5).modulo(-2), Number::ONE.mul(-1));
     /// ```
     pub fn modulo(&self, other: impl Into<Self>) -> Result<Self> {
         todo!()

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -233,9 +233,9 @@ impl Number {
     ///     // Number same as base
     ///     assert_eq!(a.log(a)?, Number::ONE);
     ///     // Product rule log(xy) == log(x) + log(y)
-    ///     assert_eq!(a.mul(b)?.log(base), a.log(base).add(b.log(base)?));
+    ///     assert_eq!(a.mul(b)?.log(base), a.log(base)?.add(b.log(base)?));
     ///     // Quotient rule log(x/y) == log(x) - log(y)
-    ///     assert_eq!(a.div(b)?.log(base), a.log(base).sub(b.log(base)?));
+    ///     assert_eq!(a.div(b)?.log(base), a.log(base)?.sub(b.log(base)?));
     ///     // Log of power log(x^y) == y * log(x)
     ///     assert_eq!(a.pow(b)?.log(base), b.mul(a.log(base)?));
     ///     // Log of one

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -200,6 +200,20 @@ impl Number {
         todo!()
     }
 
+    /// Get the absolute value of the given number
+    ///
+    /// ```
+    /// # use math::Number;
+    /// let a = Number::random();
+    /// let neg_a = a.mul(-1);
+    ///
+    /// assert_eq!(a.abs(), Ok(a));
+    /// assert_eq!(neg_a.abs(), Ok(a));
+    /// ```
+    pub fn abs(&self) -> Result<Self> {
+        todo!()
+    }
+
     /// Calculate factorial of a given number
     /// The number is not limited to integer, it can be a fraction
     ///

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -15,6 +15,9 @@ impl Number {
     /// 0.0
     pub const ZERO: Self = Self { inner: 0.0 };
 
+    /// 1.0
+    pub const ONE: Self = Self { inner: 1.0 };
+
     /// 3.14159...
     pub const PI: Self = Self {
         inner: std::f64::consts::PI,
@@ -147,6 +150,7 @@ impl Number {
     /// assert!(random.div(Number::ZERO).is_err());
     /// assert_eq!(Number::ZERO.div(random), Number::ZERO);
     /// assert_eq!(rand.div(rand), Number::ONE);
+    ///
     /// let a = Number::from(3);
     /// let b = Number::from(1.5);
     /// let neg_b = Number::from(-1.5);
@@ -154,6 +158,20 @@ impl Number {
     /// assert_eq!(a.div(neg_b), Ok(Number::from(-2)))
     /// ```
     pub fn div(&self, other: impl Into<Self>) -> Result<Self> {
+        todo!()
+    }
+
+    /// Calculate factorial of a given number
+    /// The number is not limited to integer, it can be a fraction
+    ///
+    /// # Error
+    /// return
+    /// ```
+    /// assert_eq!(Number::Zero.factorial(), Number::One);
+    /// assert_eq!(Number::from(5).factorial(), Ok(Number::from(120)));
+    /// assert!(Number::from(-1).factorial().is_err());
+    /// ```
+    pub fn factorial(&self) -> Result<Self> {
         todo!()
     }
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -7,6 +7,12 @@ pub struct Number {
     inner: f64,
 }
 
+impl<T: Into<f64>> From<T> for Number {
+    fn from(v: T) -> Self {
+        Self { inner: v.into() }
+    }
+}
+
 impl AsRef<f64> for Number {
     fn as_ref(&self) -> &f64 {
         &self.inner

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use std::cmp::Ordering;
 
 /// Represent a number
+#[derive(Debug)]
 pub struct Number {
     inner: f64,
 }

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -211,7 +211,7 @@ impl Number {
     /// # use math::Number;
     /// assert_eq!(Number::Zero.factorial(), Number::One);
     /// assert_eq!(Number::from(5).factorial(), Ok(Number::from(120)));
-    /// assert_eq!(Number::from(3.2).factorial().unwrap().to_string(6), "7.756689");
+    /// assert_eq!(Number::from(3.2).factorial().unwrap().to_string(6), "7.75669");
     /// assert!(Number::from(-1).factorial().is_err());
     /// ```
     pub fn factorial(&self) -> Result<Self> {


### PR DESCRIPTION
# Change
The `Number` API is now looks like this
```rs
pub fn to_string(&self, radix: Radix, precision: u8) -> String;
```

Where `Radix` is an enum of { Bin, Oct, Dec, Hex } and the `precision` is maximum number of fraction part of the Number

# Unit tests
The unit tests is written directly in the documentation since it's [the Rust way of writing unit test for functions](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html), it also demonstates how the function works while reading the documentation.

Please @TheRetikGM @Blazeo7 review them for me in case I missed something that can lead into undefined behaviour like division zero, especially for those trigonometric functions.

# Tasks
- [x] Documentation 
- [x] Unit tests
- [ ] Random
- [ ] Basic arithmetic operation
    - [ ] Add
    - [ ] Sub
    - [ ] Mul
    - [ ] Div
- [ ] Pow
- [ ] Abs 
- [ ] Factorial
- [ ] Logarithm
    - [ ] log
    - [ ] log2
    - [ ] log10
    - [ ] ln 
- [ ] root
    - [ ] sqrt
- [ ] Trigonometric functions
    - [ ] sin
    - [ ] cos
    - [ ] tg
    - [ ] cotg
- [ ] Inverse trigonometric functions
    - [ ] arcsin
    - [ ] arccos
    - [ ] arctg
    - [ ] arccotg
- [ ] Combination