### PR TITLE
Add `Calculator` API

### DIFF
--- a/src/math/src/engine.rs
+++ b/src/math/src/engine.rs
@@ -225,7 +225,6 @@ fn operator_precedence(op: Operator) -> u8 {
 }
 
 fn evaluate_expr(lhs: Number, rhs: Number, op: Operator) -> Result<Number> {
-    // dbg!(&lhs, &op, &rhs);
     match op {
         Operator::Plus => lhs.add(rhs),
         Operator::Minus => lhs.sub(rhs),

--- a/src/math/src/engine.rs
+++ b/src/math/src/engine.rs
@@ -1,0 +1,61 @@
+use crate::error::Error;
+use crate::token::Token;
+use crate::Variable;
+use crate::{Number, Result};
+use std::collections::HashMap;
+
+/// The Engine trait
+/// This trait contains 2 parts. `evaluate` and `validate_tokens`
+/// The `validate_tokens` ensures that the input is valid for the current `Engine`
+///
+pub trait Engine {
+    /// Validate the given token list to ensure that it's executable
+    /// This *only* do the syntatical check shouldn't perform any heavy operation
+    fn validate_tokens(
+        &mut self,
+        token: &[Token],
+        variables: &HashMap<String, Variable>,
+    ) -> Result<()>;
+
+    /// Evaluate the token list
+    /// This function will always be call *after* `validate_tokens`, so it don't need to check for
+    /// the correctness of Token list
+    fn evaluate(
+        &mut self,
+        tokens: &[Token],
+        variables: &HashMap<String, Variable>,
+    ) -> Result<Number>;
+
+    /// Call`validate_tokens` then `evaluate` it immediately
+    fn execute(
+        &mut self,
+        token: &[Token],
+        variables: &HashMap<String, Variable>,
+    ) -> Result<Number> {
+        self.validate_tokens(token, variables)?;
+        self.evaluate(token, variables)
+    }
+}
+
+#[derive(Default)]
+/// An modification of the shunting yard algorithm for evaluate infix math notation that allows
+/// functions/constants being used
+pub struct ShuntingYardEngine;
+
+impl Engine for ShuntingYardEngine {
+    fn validate_tokens(
+        &mut self,
+        token: &[Token],
+        variables: &HashMap<String, Variable>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn evaluate(
+        &mut self,
+        tokens: &[Token],
+        variables: &HashMap<String, Variable>,
+    ) -> Result<Number> {
+        todo!()
+    }
+}

--- a/src/math/src/engine.rs
+++ b/src/math/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::token::Token;
+use crate::token::*;
 use crate::Variable;
 use crate::{Number, Result};
 use std::collections::HashMap;
@@ -37,10 +37,24 @@ pub trait Engine {
     }
 }
 
+enum ShuntingYardOperator {
+    Operator(Operator),
+    OpenParen,
+    Variable(Variable),
+}
+
+enum Sign {
+    Plus,
+    Minus,
+}
+
 #[derive(Default)]
 /// An modification of the shunting yard algorithm for evaluate infix math notation that allows
 /// functions/constants being used
-pub struct ShuntingYardEngine;
+pub struct ShuntingYardEngine {
+    operators: Vec<ShuntingYardOperator>,
+    operands: Vec<Number>,
+}
 
 impl Engine for ShuntingYardEngine {
     fn validate_tokens(
@@ -48,7 +62,7 @@ impl Engine for ShuntingYardEngine {
         token: &[Token],
         variables: &HashMap<String, Variable>,
     ) -> Result<()> {
-        todo!()
+        Ok(())
     }
 
     fn evaluate(
@@ -56,6 +70,111 @@ impl Engine for ShuntingYardEngine {
         tokens: &[Token],
         variables: &HashMap<String, Variable>,
     ) -> Result<Number> {
-        todo!()
+        self.operators.clear();
+        self.operands.clear();
+
+        for token in tokens {
+            match token {
+                Token::Number(num) => self.store_operand(num.clone()),
+                Token::Operator(op) => self.operator_handle(*op)?,
+                Token::FactorialSign => {
+                    let num = self.operands.pop().unwrap().factorial()?;
+                    self.store_operand(num);
+                }
+
+                Token::Bracket(Bracket::ParenLeft) => {
+                    self.operators.push(ShuntingYardOperator::OpenParen);
+                }
+                Token::Bracket(Bracket::ParenRight) => self.closing_bracket_handle()?,
+                Token::Bracket(Bracket::VerticalLine) => todo!(),
+                Token::Id(id) => {
+                    let var = variables.get(id).cloned().unwrap();
+                    self.operators.push(ShuntingYardOperator::Variable(var));
+                }
+                Token::Comma => (),
+            }
+        }
+
+        Ok(self.operands.pop().unwrap_or_default())
+    }
+}
+
+fn operator_precedence(op: Operator) -> u8 {
+    match op {
+        Operator::Plus | Operator::Minus => 0,
+        Operator::Multiply | Operator::Divide => 1,
+        Operator::Power => 2,
+    }
+}
+
+fn evaluate_expr(lhs: Number, rhs: Number, op: Operator) -> Result<Number> {
+    match op {
+        Operator::Plus => lhs.add(rhs),
+        Operator::Minus => lhs.sub(rhs),
+        Operator::Multiply => lhs.mul(rhs),
+        Operator::Divide => lhs.div(rhs),
+        Operator::Power => lhs.power(rhs),
+    }
+}
+
+impl ShuntingYardEngine {
+    fn store_operand(&mut self, val: Number) {
+        self.operands.push(val);
+    }
+
+    fn operator_handle(&mut self, op: Operator) -> Result<()> {
+        let current_precedence = operator_precedence(op);
+
+        while let Some(ShuntingYardOperator::Operator(last_op)) = self.operators.last() {
+            if current_precedence > operator_precedence(*last_op) {
+                break;
+            }
+
+            let lhs = self.operands.pop().unwrap();
+            let rhs = self.operands.pop().unwrap();
+            self.store_operand(evaluate_expr(lhs, rhs, *last_op)?);
+            self.operators.pop();
+        }
+
+        self.operators.push(ShuntingYardOperator::Operator(op));
+        Ok(())
+    }
+
+    fn closing_bracket_handle(&mut self) -> Result<()> {
+        if let Some(num) = self.finalize()? {
+            self.store_operand(num);
+            return Ok(());
+        }
+
+        if let Some(ShuntingYardOperator::Variable(var)) = self.operators.last() {
+            let argc = var.argc();
+            let mut argv = Vec::with_capacity(argc as usize);
+
+            for _ in 0..argc {
+                argv.insert(0, self.operands.pop().unwrap());
+            }
+
+            let val = var.calc(&argv)?;
+            self.operators.pop();
+            self.store_operand(val);
+        }
+
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> Result<Option<Number>> {
+        let mut res = None;
+
+        while let Some(operator) = self.operators.pop() {
+            let ShuntingYardOperator::Operator(op) = operator else {
+                break;
+            };
+
+            let rhs = res.clone().or_else(|| self.operands.pop()).unwrap();
+            let lhs = self.operands.pop().unwrap();
+            res.replace(evaluate_expr(lhs, rhs, op)?);
+        }
+
+        Ok(res)
     }
 }

--- a/src/math/src/error.rs
+++ b/src/math/src/error.rs
@@ -38,6 +38,22 @@ pub enum Error {
     /// Error message
     Message(String),
 
+    #[error("Missing operand to process")]
+    /// Missing operand
+    MissingOperand,
+
+    #[error("Missing operator to process")]
+    /// Missing operator
+    MissingOperator,
+
+    #[error("Invalid Arguments")]
+    /// Invalid Function Arguments
+    InvalidArguments,
+
+    #[error("Invalid Token")]
+    /// Invalid Token
+    InvalidToken,
+
     #[error("The token at index `{0}` isn't valid")]
     /// Unsupported Token
     UnsupportedToken(usize),

--- a/src/math/src/lib.rs
+++ b/src/math/src/lib.rs
@@ -115,13 +115,13 @@ impl Calculator {
     /// assert_eq!(calculator.add_constant("pi", Number::from(3)), true);
     /// assert_eq!(calculator.add_constant("sqrt", Number::random()), false);
     /// ```
-    pub fn add_constant(&mut self, name: &str, num: Number) -> bool {
+    pub fn add_constant(&mut self, name: &str, num: impl Into<Number>) -> bool {
         let name = name.to_lowercase();
         if matches!(self.variables.get(&name), Some(Variable::Function { .. })) {
             return false;
         }
 
-        self.variables.insert(name, Variable::Constant(num));
+        self.variables.insert(name, Variable::Constant(num.into()));
         true
     }
 
@@ -150,6 +150,35 @@ impl Calculator {
                 None
             }
         }
+    }
+
+    /// Get a specific constant value
+    ///
+    /// ```
+    /// # use math::{Number, Calculator};
+    /// let mut calculator = Calculator::new();
+    ///
+    /// assert_eq!(calculator.get_constant("pi"), Some(Number::pi()));
+    /// assert_eq!(calculator.get_constant("my_const"), None);
+    ///
+    /// calculator.add_constant("my_const", 1);
+    /// assert_eq!(calculator.get_constant("my_const"), Some(Number::from(1)));
+    /// ```
+    pub fn get_constant(&self, name: &str) -> Option<Number> {
+        let name = name.to_lowercase();
+        match self.variables.get(&name)? {
+            Variable::Constant(num) => Some(num.clone()),
+            _ => None,
+        }
+    }
+
+    /// Get an `Iterator` over all constants that the `Calculator` currently holding
+    /// ```
+    pub fn constants(&self) -> impl Iterator<Item = (&str, Number)> {
+        self.variables.iter().filter_map(|(name, var)| match var {
+            Variable::Constant(val) => Some((name.as_str(), val.clone())),
+            _ => None,
+        })
     }
 
     /// Set the engine of the `Calculator`

--- a/src/math/src/lib.rs
+++ b/src/math/src/lib.rs
@@ -59,7 +59,30 @@ impl Calculator {
     }
 
     fn add_basic_function(&mut self) {
-        // TODO
+        let mut add_function = |name: &str, argc, ptr| {
+            self.variables
+                .insert(name.to_lowercase(), Variable::Function { argc, ptr })
+        };
+
+        add_function("root", 2, |nums| nums[1].root(&nums[0]));
+        add_function("sqrt", 1, |nums| nums[0].sqrt());
+        add_function("ln", 1, |nums| nums[0].ln());
+        add_function("log2", 1, |nums| nums[0].log2());
+        add_function("log10", 1, |nums| nums[0].log10());
+        add_function("log", 2, |nums| nums[1].log(&nums[0]));
+        add_function("sin", 1, |nums| nums[0].sin());
+        add_function("cos", 1, |nums| nums[0].cos());
+        add_function("tg", 1, |nums| nums[0].tg());
+        add_function("cotg", 1, |nums| nums[0].cotg());
+        add_function("arcsin", 1, |nums| nums[0].arcsin());
+        add_function("arccos", 1, |nums| nums[0].arccos());
+        add_function("arctg", 1, |nums| nums[0].arctg());
+        add_function("arccotg", 1, |nums| nums[0].arccotg());
+        add_function("arccotg", 1, |nums| nums[0].arccotg());
+        add_function("pow", 2, |nums| nums[0].power(&nums[1]));
+        add_function("abs", 1, |nums| nums[0].abs());
+        add_function("comb", 2, |nums| Number::combination(&nums[0], &nums[1]));
+        add_function("random", 0, |_| Ok(Number::random()));
     }
 
     /// Add new constant or update existing one to the calculator

--- a/src/math/src/lib.rs
+++ b/src/math/src/lib.rs
@@ -9,28 +9,113 @@ pub mod error;
 /// Number type
 pub mod number;
 
+/// Token parsing
+pub mod token;
+
+/// Engine to perform math evaluation
+pub mod engine;
+
+use std::collections::HashMap;
+
+pub use engine::Engine;
 pub use number::Number;
 
 /// Result type for this library
 pub type Result<T> = std::result::Result<T, error::Error>;
 
+/// Defined variable
+pub enum Variable {
+    /// A constant, same as a function without parameter
+    Constant(Number),
+
+    /// A function
+    Function {
+        /// Number of parameters
+        argc: u8,
+        /// Pointer to the function itself
+        ptr: fn(&[Number]) -> Result<Number>,
+    },
+}
+
 /// Calculator struct
-pub struct Calculator;
+pub struct Calculator {
+    tokens: Vec<token::Token>,
+    engine: Box<dyn Engine>,
+    variables: HashMap<String, Variable>,
+}
 
 impl Calculator {
     /// Create a new instance
     pub fn new() -> Self {
-        Self
+        let mut res = Self {
+            tokens: Vec::new(),
+            variables: HashMap::new(),
+            engine: Box::new(engine::ShuntingYardEngine::default()) as Box<_>,
+        };
+
+        res.add_basic_function();
+
+        res
     }
-    /// Evaluate the infix math expression
-    pub fn evaluate(&mut self, _s: &str) -> Result<Number> {
-        todo!();
+
+    fn add_basic_function(&mut self) {
+        // TODO
+    }
+
+    /// Add new constant or update existing one to the calculator
+    /// Name is *case-insensitive*
+    /// Naming of the constant shouldn't match with any built-in functions like `sqrt`, `log`, etc
+    /// ```
+    /// # use math::Calculator;
+    /// # use math::Number;
+    /// let mut calculator = Calculator::new();
+    /// assert_eq!(calculator.add_constant("pi", Number::from(3)), true);
+    /// assert_eq!(calculator.add_constant("sqrt", Number::random()), false);
+    /// ```
+    pub fn add_constant(&mut self, name: &str, num: Number) -> bool {
+        let name = name.to_lowercase();
+        if matches!(self.variables.get(&name), Some(Variable::Function { .. })) {
+            return false;
+        }
+
+        self.variables.insert(name, Variable::Constant(num));
+        true
+    }
+
+    /// Set the engine of the `Calculator`
+    /// ```ignore
+    /// # use math::Calculator;
+    /// let mut calculator = Calculator::new();
+    /// let postfix_engine = MyPostFixEngine::new();
+    /// calculator.set_engine(postfix_engine);
+    /// assert_eq!(calculator.evaluate("1 2 3 * -"), Ok(Number::from(-5)));
+    /// ```
+    pub fn set_engine(&mut self, engine: impl Engine + 'static) {
+        self.engine = Box::new(engine) as Box<_>;
+    }
+
+    /// Evaluate a math expression using the given `Engine` (default is the infix math `ShuntingYardEngine`)
+    /// If the evaluation success, the constant `ANS` will be stored/updated into the variables list of the calculator
+    pub fn evaluate(&mut self, s: &str) -> Result<Number> {
+        self.tokens.clear();
+        let mut scanner = token::Scanner::new(s);
+
+        while let Some(token) = scanner.next_token()? {
+            self.tokens.push(token);
+        }
+
+        let ans = self
+            .engine
+            .execute(self.tokens.as_slice(), &self.variables)?;
+
+        self.add_constant("ans", ans.clone());
+        Ok(ans)
     }
 }
 
 /// High level function
 /// for use in the long run, it is recommendded to create (and hold) an instance of `Calculator`
 /// struct itself, as it may reserves the allocation spaces for future evaluation process
-pub fn evaluate(_s: &str) -> Result<Number> {
-    todo!()
+pub fn evaluate(s: &str) -> Result<Number> {
+    Calculator::new().evaluate(s)
 }

--- a/src/math/src/lib.rs
+++ b/src/math/src/lib.rs
@@ -98,7 +98,6 @@ impl Calculator {
         add_function("arccos", 1, |nums| nums[0].arccos());
         add_function("arctg", 1, |nums| nums[0].arctg());
         add_function("arccotg", 1, |nums| nums[0].arccotg());
-        add_function("arccotg", 1, |nums| nums[0].arccotg());
         add_function("pow", 2, |nums| nums[0].power(&nums[1]));
         add_function("abs", 1, |nums| nums[0].abs());
         add_function("comb", 2, |nums| Number::combination(&nums[0], &nums[1]));
@@ -173,7 +172,6 @@ impl Calculator {
     }
 
     /// Get an `Iterator` over all constants that the `Calculator` currently holding
-    /// ```
     pub fn constants(&self) -> impl Iterator<Item = (&str, Number)> {
         self.variables.iter().filter_map(|(name, var)| match var {
             Variable::Constant(val) => Some((name.as_str(), val.clone())),

--- a/src/math/src/number.rs
+++ b/src/math/src/number.rs
@@ -259,11 +259,11 @@ impl Number {
         let rhs = other.into();
 
         if rhs == Self::zero() {
-            return Ok(rhs);
+            return Ok(self.clone());
         }
 
         if self == &Self::zero() {
-            return Ok(self.clone());
+            return Ok(rhs);
         }
 
         let res = &*self.inner + &*rhs.inner;

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -326,12 +326,9 @@ impl<'a> Scanner<'a> {
                 .map(StepState::Token)
         };
 
-        dbg!(ch);
         let Some(mut state) = self.state.next_state(ch).map_err(|_| Error::UnsupportedToken(self.cnt))? else {
             return Ok(StepState::Inprogress);
         };
-
-        dbg!(&state);
 
         mem::swap(&mut state, &mut self.state);
 

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -1,0 +1,284 @@
+use crate::error::Error;
+use crate::number::Number;
+use crate::Result;
+use num::BigInt;
+use std::mem;
+
+#[derive(Debug, Clone, Copy)]
+/// Representation of a bracket
+pub enum Bracket {
+    /// (
+    ParenLeft,
+    /// )
+    ParenRight,
+    /// |
+    VerticalLine,
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Representation of a mathematical operator
+pub enum Operator {
+    /// +
+    Plus,
+    /// -
+    Minus,
+    /// *
+    Multiply,
+    /// /
+    Divide,
+    /// ^
+    Power,
+}
+
+#[derive(Debug, Clone)]
+/// Representation of a token
+pub enum Token {
+    /// Number
+    Number(Number),
+    /// Bracket `(`, `)`, `|`
+    Bracket(Bracket),
+    /// !
+    FactorialSign,
+    /// Operator `+`, `-`, `*`, `/`, `^`
+    Operator(Operator),
+    /// Idenfifier
+    Id(String),
+}
+
+#[derive(Default)]
+enum State {
+    #[default]
+    Start,
+    FactorialSign,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Pow,
+    LeftPar,
+    RightPar,
+    VerticalLine,
+    Identifier(String),
+    NumberStart,
+    Number {
+        radix: u32,
+        num: BigInt,
+    },
+    FractionStart,
+    Fraction {
+        radix: u32,
+        num: BigInt,
+        fract: BigInt,
+    },
+}
+
+impl State {
+    fn to_token(self) -> Option<Token> {
+        let token = match self {
+            Self::Add => Token::Operator(Operator::Plus),
+            Self::Sub => Token::Operator(Operator::Minus),
+            Self::Mul => Token::Operator(Operator::Multiply),
+            Self::Div => Token::Operator(Operator::Divide),
+            Self::Pow => Token::Operator(Operator::Power),
+            Self::FactorialSign => Token::FactorialSign,
+            Self::LeftPar => Token::Bracket(Bracket::ParenLeft),
+            Self::RightPar => Token::Bracket(Bracket::ParenRight),
+            Self::VerticalLine => Token::Bracket(Bracket::VerticalLine),
+            Self::Identifier(s) => Token::Id(s),
+            Self::NumberStart => Token::Number(Number::zero()),
+            Self::Number { num, .. } => Token::Number(Number::from(num)),
+            Self::Fraction { num, fract, .. } => {
+                let num = Number::from(num);
+                let mut tmp = fract.clone();
+                let mut fract_cnt = 0;
+
+                while tmp != num::zero() {
+                    tmp >>= 0;
+                    fract_cnt += 1;
+                }
+
+                let fract = Number::new(fract, 10u128.pow(fract_cnt)).unwrap_or_default();
+                Token::Number(num.add(fract).unwrap_or_default())
+            }
+
+            _ => return None,
+        };
+
+        Some(token)
+    }
+
+    fn next_state(&mut self, ch: char) -> Result<Option<State>> {
+        let next = match self {
+            Self::FactorialSign
+            | Self::LeftPar
+            | Self::RightPar
+            | Self::VerticalLine
+            | Self::Add
+            | Self::Sub
+            | Self::Mul
+            | Self::Div
+            | Self::Pow => Some(Self::Start),
+            Self::Start => {
+                let next_state = match ch {
+                    ')' => State::RightPar,
+                    '(' => State::LeftPar,
+                    '|' => State::VerticalLine,
+                    '+' => State::Add,
+                    '-' => State::Sub,
+                    '*' => State::Mul,
+                    '/' => State::Div,
+                    '^' => State::Pow,
+                    '!' => State::FactorialSign,
+                    '0' => State::NumberStart,
+                    '1'..='9' => State::Number {
+                        radix: 10,
+                        num: BigInt::from(ch.to_digit(10).unwrap()),
+                    },
+                    '.' => State::FractionStart,
+                    'a'..='z' | 'A'..='Z' => State::Identifier(ch.to_string()),
+
+                    _ => return Err(Error::UnsupportedToken(0)),
+                };
+
+                Some(next_state)
+            }
+
+            Self::Identifier(ref mut s) => 'id: {
+                if !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9') {
+                    break 'id Some(State::Start);
+                }
+
+                s.push(ch);
+                None
+            }
+            Self::NumberStart => match ch {
+                '.' => Some(Self::Fraction {
+                    radix: 10,
+                    num: Default::default(),
+                    fract: Default::default(),
+                }),
+                'b' => Some(Self::Number {
+                    radix: 2,
+                    num: Default::default(),
+                }),
+                'o' => Some(Self::Number {
+                    radix: 8,
+                    num: Default::default(),
+                }),
+                'x' => Some(Self::Number {
+                    radix: 16,
+                    num: Default::default(),
+                }),
+                '0'..='9' => Some(Self::Number {
+                    radix: 10,
+                    num: BigInt::from(ch.to_digit(10).unwrap()),
+                }),
+                _ => Some(Self::Start),
+            },
+
+            Self::Number { radix, ref mut num } => 'number: {
+                if ch == '.' {
+                    break 'number Some(Self::Fraction {
+                        radix: *radix,
+                        num: mem::take(num),
+                        fract: Default::default(),
+                    });
+                }
+
+                let Some(val) = ch.to_digit(*radix) else {
+                    break 'number Some(Self::Start);
+                };
+
+                *num *= *radix;
+                *num += val;
+
+                None
+            }
+
+            Self::FractionStart => {
+                let Some(val) = ch.to_digit(10) else {
+                    return Err(Error::UnsupportedToken(0));
+                };
+
+                Some(Self::Fraction {
+                    radix: 10,
+                    num: num::zero(),
+                    fract: BigInt::from(val),
+                })
+            }
+
+            Self::Fraction {
+                radix,
+                ref mut fract,
+                ..
+            } => 'fraction: {
+                let Some(val) = ch.to_digit(*radix) else {
+                    break 'fraction Some(Self::Start);
+                };
+
+                *fract *= *radix;
+                *fract += val;
+
+                None
+            }
+        };
+
+        Ok(next)
+    }
+}
+
+/// Scan tokens from string
+pub struct Scanner<'a> {
+    iter: std::str::Chars<'a>,
+    state: State,
+    cnt: usize,
+}
+
+impl<'a> Scanner<'a> {
+    /// Create a new scanner to scan the given `s`
+    pub fn new(s: &'a str) -> Self {
+        Self {
+            iter: s.chars(),
+            state: State::Start,
+            cnt: 0,
+        }
+    }
+
+    /// Scan the given string into list of `Token`
+    pub fn scan(&mut self) -> Result<Vec<Token>> {
+        let mut res = Vec::new();
+
+        while let Some(token) = self.step()? {
+            res.push(token);
+        }
+
+        Ok(res)
+    }
+
+    fn step(&mut self) -> Result<Option<Token>> {
+        let ch = match self.iter.next() {
+            Some(ch) => ch,
+            None if matches!(self.state, State::Start) => return Ok(None),
+            None => {
+                return mem::take(&mut self.state)
+                    .to_token()
+                    .ok_or(Error::UnsupportedToken(self.cnt))
+                    .map(Some)
+            }
+        };
+        self.cnt += 1;
+
+        let Some(mut state) = self.state.next_state(ch).map_err(|_| Error::UnsupportedToken(self.cnt))? else {
+            return Ok(None);
+        };
+
+        mem::swap(&mut state, &mut self.state);
+
+        if let State::Start = self.state {
+            self.iter.next_back();
+            Ok(state.to_token())
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -4,9 +4,12 @@
 //! # use math::token::{Token, Bracket, Operator, Scanner};
 //! # use math::Number;
 //! # fn main() -> math::Result<()> {
-//! let s = "1.1 + 3 - .5e()root(7, 5!)";
+//! let s = "pi()1.1 + 3 - .5e()root(sqrt(8), 5!)";
 //! let mut scanner = Scanner::new(s);
 //!
+//! assert_eq!(scanner.next_token()?, Some(Token::Id(String::from("pi"))));
+//! assert_eq!(scanner.next_token()?, Some(Token::Bracket(Bracket::ParenLeft)));
+//! assert_eq!(scanner.next_token()?, Some(Token::Bracket(Bracket::ParenRight)));
 //! assert_eq!(scanner.next_token()?, Some(Token::Number(Number::new(11, 10)?)));
 //! assert_eq!(scanner.next_token()?, Some(Token::Operator(Operator::Plus)));
 //! assert_eq!(scanner.next_token()?, Some(Token::Number(Number::from(3))));
@@ -17,7 +20,10 @@
 //! assert_eq!(scanner.next_token()?, Some(Token::Bracket(Bracket::ParenRight)));
 //! assert_eq!(scanner.next_token()?, Some(Token::Id(String::from("root"))));
 //! assert_eq!(scanner.next_token()?, Some(Token::Bracket(Bracket::ParenLeft)));
-//! assert_eq!(scanner.next_token()?, Some(Token::Number(Number::from(7))));
+//! assert_eq!(scanner.next_token()?, Some(Token::Id(String::from("sqrt"))));
+//! assert_eq!(scanner.next_token()?, Some(Token::Bracket(Bracket::ParenLeft)));
+//! assert_eq!(scanner.next_token()?, Some(Token::Number(Number::from(8))));
+//! assert_eq!(scanner.next_token()?, Some(Token::Bracket(Bracket::ParenRight)));
 //! assert_eq!(scanner.next_token()?, Some(Token::Comma));
 //! assert_eq!(scanner.next_token()?, Some(Token::Number(Number::from(5))));
 //! assert_eq!(scanner.next_token()?, Some(Token::FactorialSign));

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -179,7 +179,7 @@ impl State {
                         num: BigUint::from(ch.to_digit(10).unwrap()),
                     },
                     '.' => State::FractionStart,
-                    'a'..='z' | 'A'..='Z' => State::Identifier(ch.to_string()),
+                    'a'..='z' | 'A'..='Z' | '_' => State::Identifier(ch.to_string()),
 
                     _ => return Err(Error::UnsupportedToken(0)),
                 };
@@ -188,7 +188,7 @@ impl State {
             }
 
             Self::Identifier(ref mut s) => 'id: {
-                if !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9') {
+                if !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_') {
                     break 'id Some(State::Start);
                 }
 


### PR DESCRIPTION
The `Calculator` struct API, I would say that it is fully working API, the only thing left to do is to implement an `Engine`

# Calculator
```rs
impl Calculator {
    fn new() -> Self;
    fn add_constant(&mut self, name: &str, value: Number) -> bool;
    fn get_constant(&self, name: &str) -> Option<Number>;
    fn remove_constant(&mut self, name: &str) -> Option<Number>;
    fn constants(&self) -> impl Iterator<Item=(&str, Number)>;
    fn evaluate(&mut self, expression: &str) -> math::Result<Number>;
}

fn evaluate(expression: &str) -> Result<Number>;
```

- Custom constant can be added/updated via `add_constant` function, and its name is case-insensitive
- If `evaluation` function call succeeds, it will put the result as `ANS` into the constant list automatically, so the next expression with `ANS()` will give the value of the last expression

The `evaluation` function outside of the `Calculator` struct is simply shorthand for `Calculator::new().evaluate(expression)`