### PR TITLE
Add `^` and `mod` binary operators

### DIFF
--- a/src/math/src/engine.rs
+++ b/src/math/src/engine.rs
@@ -67,7 +67,12 @@ impl Engine for ShuntingYardEngine {
 
                 (
                     Token::Operator(_),
-                    Some(Token::Operator(Operator::Divide | Operator::Multiply)),
+                    Some(Token::Operator(
+                        Operator::Divide
+                        | Operator::Multiply
+                        | Operator::Modulo
+                        | Operator::Remainder,
+                    )),
                 ) => return Err(Error::MissingOperand),
 
                 (Token::Number(_), Some(Token::Number(_))) => return Err(Error::MissingOperator),
@@ -164,14 +169,24 @@ impl Engine for ShuntingYardEngine {
                         (
                             None
                             | Some(&Token::Comma)
-                            | Some(&Token::Operator(Operator::Multiply | Operator::Divide)),
+                            | Some(&Token::Operator(
+                                Operator::Multiply
+                                | Operator::Divide
+                                | Operator::Modulo
+                                | Operator::Remainder,
+                            )),
                             Operator::Plus,
                             Some(Token::Number(_)),
                         ) => continue,
                         (
                             None
                             | Some(&Token::Comma)
-                            | Some(&Token::Operator(Operator::Multiply | Operator::Divide)),
+                            | Some(&Token::Operator(
+                                Operator::Multiply
+                                | Operator::Divide
+                                | Operator::Remainder
+                                | Operator::Modulo,
+                            )),
                             Operator::Minus,
                             Some(Token::Number(_)),
                         ) => {
@@ -220,7 +235,7 @@ fn operator_precedence(op: Operator) -> u8 {
     match op {
         Operator::Plus | Operator::Minus => 0,
         Operator::Multiply | Operator::Divide => 1,
-        Operator::Power => 2,
+        Operator::Power | Operator::Modulo | Operator::Remainder => 2,
     }
 }
 
@@ -231,6 +246,8 @@ fn evaluate_expr(lhs: Number, rhs: Number, op: Operator) -> Result<Number> {
         Operator::Multiply => lhs.mul(rhs),
         Operator::Divide => lhs.div(rhs),
         Operator::Power => lhs.power(rhs),
+        Operator::Modulo => lhs.modulo(rhs),
+        Operator::Remainder => lhs.remainder(rhs),
     }
 }
 

--- a/src/math/src/lib.rs
+++ b/src/math/src/lib.rs
@@ -83,7 +83,7 @@ impl Calculator {
         res.add_constant("pi", Number::pi());
 
         let mut keywords = res.add_builtin_function();
-        keywords.extend_from_slice(&["rem", "mod"]);
+        keywords.push("mod");
         res.builtin_keywords = keywords.into_boxed_slice();
 
         res

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -128,8 +128,12 @@ impl State {
             Self::Identifier(s) => Token::Id(s),
             Self::NumberStart => Token::Number(Number::zero()),
             Self::Number { num, .. } => Token::Number(Number::from(num)),
-            Self::Fraction { num, fract_cnt, .. } => {
-                let val = Number::new(num, 10u128.pow(fract_cnt)).unwrap_or_default();
+            Self::Fraction {
+                num,
+                fract_cnt,
+                radix,
+            } => {
+                let val = Number::new(num, BigUint::from(radix).pow(fract_cnt)).unwrap_or_default();
                 Token::Number(val)
             }
 

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -66,8 +66,6 @@ pub enum Operator {
     Power,
     /// Modulo,
     Modulo,
-    /// Remainder
-    Remainder,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,7 +129,6 @@ impl State {
             Self::VerticalLine => Token::Bracket(Bracket::VerticalLine),
             Self::Identifier(s) => match s.as_str() {
                 "mod" => Token::Operator(Operator::Modulo),
-                "rem" => Token::Operator(Operator::Remainder),
                 _ => Token::Id(s),
             },
             Self::NumberStart => Token::Number(Number::zero()),

--- a/src/math/src/token.rs
+++ b/src/math/src/token.rs
@@ -64,6 +64,10 @@ pub enum Operator {
     Divide,
     /// ^
     Power,
+    /// Modulo,
+    Modulo,
+    /// Remainder
+    Remainder,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,7 +129,11 @@ impl State {
             Self::LeftPar => Token::Bracket(Bracket::ParenLeft),
             Self::RightPar => Token::Bracket(Bracket::ParenRight),
             Self::VerticalLine => Token::Bracket(Bracket::VerticalLine),
-            Self::Identifier(s) => Token::Id(s),
+            Self::Identifier(s) => match s.as_str() {
+                "mod" => Token::Operator(Operator::Modulo),
+                "rem" => Token::Operator(Operator::Remainder),
+                _ => Token::Id(s),
+            },
             Self::NumberStart => Token::Number(Number::zero()),
             Self::Number { num, .. } => Token::Number(Number::from(num)),
             Self::Fraction {

--- a/src/math/tests/evaluate.rs
+++ b/src/math/tests/evaluate.rs
@@ -63,6 +63,24 @@ fn evaluate_pow() -> math::Result<()> {
     Ok(())
 }
 #[test]
+fn evaluate_pow_infix_notation() -> math::Result<()> {
+    assert_eq!(eval_dec("-123^0", 0)?, "1");
+    assert_eq!(eval_dec("123 ^ 0", 0)?, "1");
+    assert_eq!(eval_dec("2^3 * 2^5", 0)?, "256");
+    assert_eq!(eval_dec("2^3^3", 0)?, "512");
+    assert_eq!(eval_dec("2^-2", 2)?, "0.25");
+    assert!(eval_dec("0^0^0", 3).is_ok());
+    Ok(())
+}
+#[test]
+fn evaluate_mod() -> math::Result<()> {
+    assert_eq!(eval_dec("7 mod 3", 0)?, "1");
+    assert_eq!(eval_dec("7 mod-3", 0)?, "-2");
+    assert_eq!(eval_dec("-7 mod 3", 0)?, "2");
+    assert_eq!(eval_dec("-7 mod -3", 0)?, "-1");
+    Ok(())
+}
+#[test]
 fn evaluate_root() -> math::Result<()> {
     assert_eq!(eval_dec("root(64, 2)", 0)?, "8");
     assert_eq!(eval_dec("root(-64, 3)", 0)?, "-4");


### PR DESCRIPTION
Add `^` and `mod` into the binary operator family, like `+` `-` `*` `/`

## Priority
The priority of binary operator is as shown in the precedence table below, higher precedence's value means higher priority
| Operator | Value |
|-----------|------------|
| `+` `-` | 1 |
| `*` `/` | 2 |
| `^` `mod` | 3 |

## Associativity
According to [Wikipedia](https://en.wikipedia.org/wiki/Operator_associativity), there is no general agreement for `exponentiation` and `modulo`. So I decided to make them left associative like other operators. 
For example `2 ^ 3 ^ 3 = (2 ^ 3) ^ 3 = 512`, if it was right associative, the expression will be `2 ^ (3 ^ 3) = 134217728`

### Side notes
- The keyword `mod` as a constant name is now prohibited.
- The `pow` function still stays there and it does the same thing as the `^` operator

@TheRetikGM @Blazeo7 What do you guys think about these decisions?