### PR TITLE
Add hidden multiplication sign as in algebraic notation

### DIFF
--- a/src/math/src/engine.rs
+++ b/src/math/src/engine.rs
@@ -213,6 +213,27 @@ impl Engine for ShuntingYardEngine {
                 }
             }
 
+            // Handle the hidden multiply sign in algebraic notation
+            if let Some(next_token) = iter.peek() {
+                if token != *next_token {
+                    let left = matches!(
+                        token,
+                        Token::Number(_)
+                            | Token::FactorialSign
+                            | Token::Bracket(Bracket::ParenRight)
+                    );
+
+                    let right = matches!(
+                        next_token,
+                        Token::Number(_) | Token::Id(_) | Token::Bracket(Bracket::ParenLeft)
+                    );
+
+                    if left && right {
+                        self.operator_handle(Operator::Multiply)?;
+                    }
+                }
+            }
+
             last_token.replace(token);
         }
 

--- a/src/math/tests/evaluate.rs
+++ b/src/math/tests/evaluate.rs
@@ -235,6 +235,15 @@ fn evaluate_expr() -> math::Result<()> {
 }
 
 #[test]
+fn evaluate_expr_hidden_multiply_sign() -> math::Result<()> {
+    assert_eq!(eval_dec("3pi()", 5)?, "9.42478");
+    assert_eq!(eval_dec("e()pi()", 5)?, "8.53973");
+    assert_eq!(eval_dec("1 + 2(3 + 4!e())", 5)?, "137.47752");
+    assert_eq!(eval_dec("pi()2 / 2", 5)?, "3.14159");
+    Ok(())
+}
+
+#[test]
 fn evaluate_constants() -> math::Result<()> {
     assert_eq!(eval_dec("pi()", 6)?, "3.141593");
     assert_eq!(eval_dec("e()", 6)?, "2.718282");


### PR DESCRIPTION
In algebraic notation that is used in every math, the multiplication sign is usually hidden between number/variables/brackets. For example:
- 5pi => 5 * pi
- 2(1 + 2) => 2 * (1 + 2)
- 3!e => 3! * e

This PR adds support for this.
